### PR TITLE
Remove trailing . from marathon.app.cpu.allocated

### DIFF
--- a/marathon.py
+++ b/marathon.py
@@ -323,7 +323,7 @@ class MarathonAppCollector(Collector):
                 'metrics': [
                     {
                         'type': 'gauge',
-                        'name': 'marathon.app.cpu.allocated.',
+                        'name': 'marathon.app.cpu.allocated',
                         'path': 'cpus'
                      },
                     {


### PR DESCRIPTION
Remove trailing . from marathon.app.cpu.allocated