### PR TITLE
Net outage resilience and python 3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dateutil>=1.5
+six>=1.4


### PR DESCRIPTION
* Make compatible with python3 via six.py dependency
* Add requirements.txt file
* Change Marathon api counter metrics to report as \
   gauges (marathon is doing the counting)
* Add error handling for when marathon host suddenly is unreachable
* Add ability to specify host and port when running standalone